### PR TITLE
adding note about blog dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Contentful Middleman is a [Middleman](http://middlemanapp.com/) extension to use
 
 Experience the power of Middleman while staying sane as a developer by letting end-users edit content in a web-based interface.
 
+
 ## Installation
+
+Note - [Middleman Blog](https://github.com/middleman/middleman-blog) is a dependency of Contenful Middleman 
 
 Add the following line to the Gemfile of your Middleman project:
 


### PR DESCRIPTION
Just a quick note in the README that middleman blog is needed for this extension. 