### PR TITLE
save local data as yaml

### DIFF
--- a/lib/contentful_middleman/local_data/file.rb
+++ b/lib/contentful_middleman/local_data/file.rb
@@ -22,7 +22,7 @@ module ContentfulMiddleman
 
       def local_data_file_path
         base_path = LocalData::Store.base_path
-        ::File.join(base_path, @path)
+        ::File.join(base_path, @path + ".yaml")
       end
     end
   end


### PR DESCRIPTION
When running `middleman contentful` I realized that middleman wasn't auto picking up the data due to the fact that the imported data files didn't have a file extension. This PR adds .yaml to the files created.