### PR TITLE
Support :api_url param

### DIFF
--- a/lib/contentful_middleman/core.rb
+++ b/lib/contentful_middleman/core.rb
@@ -19,6 +19,9 @@ module ContentfulMiddleman
     option :access_token, nil,
       'The Contentful Content Delivery API access token'
 
+    option :api_url, nil,
+      'The Contentful Content Delivery API URL'
+
     option :cda_query, {},
       'The conditions that are used on the Content Delivery API to query for blog posts'
 

--- a/lib/contentful_middleman/instance.rb
+++ b/lib/contentful_middleman/instance.rb
@@ -33,6 +33,7 @@ module ContentfulMiddleman
       @client ||= Contentful::Client.new(
         access_token:     options.access_token,
         space:            options.space.fetch(:id),
+        api_url:          options.api_url,
         dynamic_entries:  :auto,
         raise_errors:     true
       )


### PR DESCRIPTION
Add the `api_url` param so we can toggle between prod/preview modes in Middleman.