### PR TITLE
Add 'use_preview_api' option to the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Upcoming
+### Added
+* New extension option: `use_preview_api`
+
 ## 1.0.4
 ### Fixed
 * Typo in the require statements

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ activate :contentful do |f|
 end
 ```
 
-Parameter     | Description
-----------    |------------
-space         | Hash with an user choosen name for the space as key and the space id as value
-access_token  | Contentful Delivery API access token
-cda_query     | Hash describing query configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info (look for filter options there)
-content_types | Hash describing the mapping applied to entries of the imported content types
+Parameter       | Description
+----------      | ------------
+space           | Hash with an user choosen name for the space as key and the space id as value
+access_token    | Contentful Delivery API access token
+cda_query       | Hash describing query configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info (look for filter options there)
+content_types   | Hash describing the mapping applied to entries of the imported content types
+use_preview_api | Boolean to toogle the used API. Set it to `false` to use `cdn.contentful.com` (default value). Set it to `true` to use `preview.contentful.com`. More info in [the documentation](https://www.contentful.com/developers/documentation/content-delivery-api/#preview-api)
 
 You can activate the extension multiple times to import entries from different spaces.
 ## Entry mapping

--- a/lib/contentful_middleman/core.rb
+++ b/lib/contentful_middleman/core.rb
@@ -25,6 +25,9 @@ module ContentfulMiddleman
     option :content_types, {},
       'The mapping of Content Types names to ids'
 
+    option :use_preview_api, false,
+      'Use the Preview API when fetching content'
+
 
     helpers ContentfulMiddleman::Helpers
 

--- a/lib/contentful_middleman/instance.rb
+++ b/lib/contentful_middleman/instance.rb
@@ -1,5 +1,7 @@
 module ContentfulMiddleman
   class Instance
+    API_PREVIEW_URL = 'preview.contentful.com'
+
     def initialize(extension)
       @extension = extension
     end
@@ -30,12 +32,19 @@ module ContentfulMiddleman
 
     private
     def client
-      @client ||= Contentful::Client.new(
-        access_token:     options.access_token,
-        space:            options.space.fetch(:id),
-        dynamic_entries:  :auto,
-        raise_errors:     true
-      )
+      @client ||= Contentful::Client.new(client_options)
+    end
+
+    def client_options
+      client_options = {
+          access_token:     options.access_token,
+          space:            options.space.fetch(:id),
+          dynamic_entries:  :auto,
+          raise_errors:     true
+      }
+
+      client_options[:api_url] = API_PREVIEW_URL if options.use_preview_api
+      client_options
     end
 
     def options


### PR DESCRIPTION
Added a new option to the extension to allow users to toggle between production and preview endpoints

Related PR: [https://github.com/contentful-labs/contentful_middleman/pull/21](https://github.com/contentful-labs/contentful_middleman/pull/21)