### PR TITLE
Make all entries available to Mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you don't want to map all the fields by hand inherit from the Base mappper:
 
 ```ruby
 class MyAwesomeMapper < ContentfulMiddleman::Mapper::Base
-  def map(context, entry)
+  def map(context, entry, entries)
     super
     # After calling super the context object
     # will have a property for every field in the

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
 If you don't want to map all the fields by hand inherit from the Base mappper:
 
 ```ruby
-class MyAwesomeMapper < ContentfulMiddleman::Mappers::Base
+class MyAwesomeMapper < ContentfulMiddleman::Mapper::Base
   def map(context, entry)
     super
     # After calling super the context object

--- a/lib/contentful_middleman/import_task.rb
+++ b/lib/contentful_middleman/import_task.rb
@@ -29,7 +29,7 @@ module ContentfulMiddleman
         content_type_name   = @content_type_names.fetch(entry.content_type.id).to_s
         context             = ContentfulMiddleman::Context.new
 
-        content_type_mapper.new.map(context, entry)
+        content_type_mapper.new.map(context, entry, entries)
 
         LocalData::File.new(context.to_yaml, File.join(@space_name, content_type_name, entry.id))
       end

--- a/lib/contentful_middleman/mappers/base.rb
+++ b/lib/contentful_middleman/mappers/base.rb
@@ -3,7 +3,7 @@ require_relative '../commands/context'
 module ContentfulMiddleman
   module Mapper
     class Base
-      def map(context, entry)
+      def map(context, entry, entries)
         context.id = entry.id
         entry.fields.each {|k, v| map_field context, k, v}
       end


### PR DESCRIPTION
This allows for Mappers like a "back-reference" mapper which can go through all of the data, and find all entries that reference it and add them to the YAML file.  I could also see things like counts or sums on entries.  Opens up a lot of possibilities.