### PR TITLE
Use the updated_at value rather than the version to calculate the hash

### DIFF
--- a/lib/contentful_middleman/version_hash.rb
+++ b/lib/contentful_middleman/version_hash.rb
@@ -12,7 +12,7 @@ module ContentfulMiddleman
 
       def write_for_space_with_entries(space_name, entries)
         sorted_entries           = entries.sort {|a, b| a.id <=> b.id}
-        ids_and_revisions_string = sorted_entries.map {|e| "#{e.id}#{e.revision}"}.join
+        ids_and_revisions_string = sorted_entries.map {|e| "#{e.id}#{e.updated_at}"}.join
         entries_hash             = Digest::SHA1.hexdigest( ids_and_revisions_string )
 
         File.open(hashfilename(space_name), 'w') { |file| file.write(entries_hash) }


### PR DESCRIPTION
When using the preview api the revision field won't change unless the
entry is republished. This meant that even if the data in the entries
changed the version hash would stay the same